### PR TITLE
FIX: Twitter-Card image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:url" content="http://styled-components.com">
     <meta name="twitter:title" content="styled-components">
     <meta name="twitter:description" content="Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅">
-    <meta name="twitter:image" content="%PUBLIC_URL%/code-atom.png">
+    <meta name="twitter:image" content="http://styled-components.com/code-atom.png">
     <!-- Facebook -->
     <meta property="og:url" content="http://styled-components.com">
     <meta property="og:type" content="website">


### PR DESCRIPTION
Should fix the missing (due to relative path?) Twitter-Card image. %PUBLIC_URL% seems to do nothing?

![screenshot 2016-12-14 18 54 02](https://cloud.githubusercontent.com/assets/238180/21194121/0edded60-c22f-11e6-98a5-75b9ef70ba5e.png)